### PR TITLE
Support quicklook preview with no leftover files

### DIFF
--- a/plot
+++ b/plot
@@ -2,16 +2,31 @@
 
 from __future__ import division
 from numpy import *
+import getopt
 import matplotlib.pyplot as plt
+import subprocess
 import sys
+import tempfile
 
-fcns = sys.argv[1].split(';')
-minx = eval(sys.argv[2])
-maxx = eval(sys.argv[3])
+# Use quicklook instead of printing to STDOUT
+preview = False
+
+try:                                
+    opts, args = getopt.getopt(sys.argv[1:], "p")
+except getopt.GetoptError:
+    print "Unsupported option"
+    sys.exit(2)
+for opt, arg in opts:
+    if opt in ("-p"):
+        preview = True
+
+fcns = args[0].split(';')
+minx = eval(args[1])
+maxx = eval(args[2])
 plt.xlim(minx, maxx)
 try:
-  miny = float(sys.argv[4])
-  maxy = float(sys.argv[5])
+  miny = float(args[3])
+  maxy = float(args[4])
   plt.ylim(miny, maxy)
 except IndexError:
   pass
@@ -22,4 +37,11 @@ for i, f in enumerate(fcns):
   plt.plot(x, y, "-", linewidth=2)
 plt.minorticks_on()
 plt.grid(which='both', color='#aaaaaa')
-plt.savefig(sys.stdout, format='png')
+
+if (preview):
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.png') as f:
+        plt.savefig(f.name, format='png')
+        subprocess.check_call(['qlmanage', '-p', f.name], stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
+else:
+    plt.savefig(sys.stdout, format='png')
+

--- a/pplot
+++ b/pplot
@@ -1,15 +1,26 @@
 #!/usr/bin/python
 
 import matplotlib.pyplot as plt
+import subprocess
 import sys
 import re
 import getopt
+import tempfile
 
+# Use quicklook instead of printing to STDOUT
+preview = False
 marker = '.'
-opts, args = getopt.getopt(sys.argv[1:], 'l')
-for o, a in opts:
-  if o == '-l':
-    marker = '.-'
+
+try:                                
+    opts, args = getopt.getopt(sys.argv[1:], "pl")
+except getopt.GetoptError:
+    print "Unsupported option"
+    sys.exit(2)
+for opt, arg in opts:
+    if opt in ("-p"):
+        preview = True
+    if opt in ("-l"):
+        marker = '.-'
 
 x = []
 y = []   
@@ -21,4 +32,11 @@ for line in sys.stdin:
 plt.plot(x, y, marker)
 plt.minorticks_on()
 plt.grid(which='both', color='#aaaaaa')
-plt.savefig(sys.stdout, format='png')
+
+if (preview):
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.png') as f:
+        plt.savefig(f.name, format='png')
+        subprocess.check_call(['qlmanage', '-p', f.name], stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
+else:
+    plt.savefig(sys.stdout, format='png')
+


### PR DESCRIPTION
Hi,

I thought this was a great idea for a utility, thanks! I wanted to avoid file cleanup and a manual call to "qlmanage" or "open" in my own process, so I added an option (-p) that runs Quicklook on a temporary file instead of printing to STDOUT. It's backwards compatible with the existing command usage.

No worries if you don't want this functionality, but it was useful for me.

Thanks again.
